### PR TITLE
fix: always give a name at root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scss-sassdoc-parser",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scss-sassdoc-parser",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "lodash.uniq": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scss-sassdoc-parser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engines": {
     "node": ">=14"
   },

--- a/src/annotations/name.ts
+++ b/src/annotations/name.ts
@@ -1,20 +1,9 @@
-import { ParseResult } from "../types";
-
 export default function name() {
   return {
     name: "name",
 
     parse(text: string) {
       return text.trim();
-    },
-
-    // Abuse the autofill feature to rewrite the `item.context`
-    autofill(item: ParseResult) {
-      if (item.name) {
-        item.context.name = item.name;
-        // Cleanup
-        delete item.name;
-      }
     },
 
     multiple: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./types";
 export * from "./sassdoc-parser";

--- a/src/sassdoc-parser.test.ts
+++ b/src/sassdoc-parser.test.ts
@@ -88,6 +88,7 @@ test("parses a decked out function", async () => {
         "group": Array [
           "helpers",
         ],
+        "name": "to-length",
         "parameter": Array [
           Object {
             "description": "Value to add unit to",
@@ -128,6 +129,7 @@ test("parses a decked out function", async () => {
             "group": Array [
               "undefined",
             ],
+            "name": "yet-another-item",
             "require": Array [],
           },
         ],
@@ -162,6 +164,7 @@ test("parses a decked out function", async () => {
         "group": Array [
           "undefined",
         ],
+        "name": "other-item",
         "require": Array [],
       },
       Object {
@@ -186,6 +189,7 @@ test("parses a decked out function", async () => {
         "group": Array [
           "undefined",
         ],
+        "name": "yet-another-item",
         "require": Array [],
       },
     ]
@@ -247,6 +251,7 @@ $valley: #000000;
         "group": Array [
           "tokens",
         ],
+        "name": "stardew",
         "see": Array [
           Object {
             "access": "public",
@@ -268,6 +273,7 @@ $valley: #000000;
             "group": Array [
               "undefined",
             ],
+            "name": "valley",
             "todo": Array [
               "Document me",
             ],
@@ -302,6 +308,7 @@ $valley: #000000;
         "group": Array [
           "undefined",
         ],
+        "name": "stardew-alias",
         "todo": Array [
           "Document me",
         ],
@@ -326,6 +333,7 @@ $valley: #000000;
         "group": Array [
           "undefined",
         ],
+        "name": "valley",
         "todo": Array [
           "Document me",
         ],
@@ -381,6 +389,7 @@ test("parses a decked out mixin", async () => {
         "group": Array [
           "undefined",
         ],
+        "name": "_keep-it-secret",
         "output": "Sets display to hidden",
       },
       Object {
@@ -408,6 +417,7 @@ test("parses a decked out mixin", async () => {
         "group": Array [
           "undefined",
         ],
+        "name": "_keep-it-safe",
       },
       Object {
         "access": "private",
@@ -431,6 +441,7 @@ test("parses a decked out mixin", async () => {
         "group": Array [
           "undefined",
         ],
+        "name": "_ring-is",
         "parameter": Array [
           Object {
             "default": "here",
@@ -472,6 +483,7 @@ test("reads things from a path", async () => {
         "group": Array [
           "undefined",
         ],
+        "name": "valley",
         "todo": Array [
           "Document me",
         ],
@@ -508,6 +520,7 @@ test("reads things from an array of paths", async () => {
         "group": Array [
           "undefined",
         ],
+        "name": "valley",
         "todo": Array [
           "Document me",
         ],
@@ -532,10 +545,25 @@ test("reads things from an array of paths", async () => {
         "group": Array [
           "undefined",
         ],
+        "name": "stardew",
         "todo": Array [
           "Document me",
         ],
       },
     ]
   `);
+});
+
+test("gives a default name that can be overridden with the @name annotation", async () => {
+  const result = await parseString(/* scss */ `
+/// This is a test
+$primary-color: #000000;
+
+/// This is a test
+/// @name wants-to-be-the-primary-color
+$secondary-color: #000000;
+`);
+  expect(result[0].name).toEqual("primary-color");
+  expect(result[1].name).toEqual("wants-to-be-the-primary-color");
+  expect(result[1].context.name).toEqual("secondary-color");
 });

--- a/src/sassdoc-parser.ts
+++ b/src/sassdoc-parser.ts
@@ -47,6 +47,14 @@ class Parser {
     ) as Array<ParseResult>;
     data = sorter(data);
 
+    data = data.map((d) => {
+      if (!d.name) {
+        // Give everything a default name from context
+        d.name = d.context.name;
+      }
+      return d;
+    });
+
     const promises: Array<Promise<void>> = [];
     Object.keys(this.annotations.list).forEach((key: string) => {
       const annotation = this.annotations.list[key as BuiltInAnnotationNames];

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,9 @@ export interface ParseResult {
   group?: string[];
   ignore?: string[];
   link?: Link[];
+  /**
+   * The value of the name annotation if set, or the name of the function/mixin/variable as declared in the code.
+   */
   name?: string;
   output?: string;
   parameter?: Parameter[];


### PR DESCRIPTION
I expected the name to be the name from context.name if there was
no annotation. Turns out, it wasn't. Make it so.

Also, export types from index.